### PR TITLE
revised README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ immediate performance gains - see benchmark below).
 For biopython, it could look like:
 
 ```python
+from fastqandfurious import fastqandfurious
 from fastqandfurious._fastqandfurious import arrayadd_b
 from Bio.SeqRecord import SeqRecord
 from array import array

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ and a function called when yielding entries (to produce "entry" objects):
 
 ```python
 
-from fastqandfurious import fastqandfurious, entryfunc
+from fastqandfurious import fastqandfurious
+from fastqandfurious.fastqandfurious import entryfunc
 
 bufsize = 20000
 with open("a/fastq/file.fq") as fh:
@@ -146,6 +147,9 @@ file is working the same:
 
 ```python
 import gzip
+from fastqandfurious import fastqandfurious
+from fastqandfurious.fastqandfurious import entryfunc
+
 with gzip.open("a/fastq/file.fq") as fh:
     it = fastqandfurious.readfastq_iter(fh, bufsize, entryfunc)
     for entry in it:

--- a/README.md
+++ b/README.md
@@ -130,12 +130,11 @@ In a nutshell, the reader takes a file-like object, a buffersize (number of byte
 and a function called when yielding entries (to produce "entry" objects):
 
 ```python
-
 from fastqandfurious import fastqandfurious
 from fastqandfurious.fastqandfurious import entryfunc
 
 bufsize = 20000
-with open("a/fastq/file.fq") as fh:
+with open("a/fastq/file.fq", "rb") as fh:
     it = fastqandfurious.readfastq_iter(fh, bufsize, entryfunc)
     for sequence in it:
         # do something
@@ -150,7 +149,7 @@ import gzip
 from fastqandfurious import fastqandfurious
 from fastqandfurious.fastqandfurious import entryfunc
 
-with gzip.open("a/fastq/file.fq") as fh:
+with gzip.open("a/fastq/file.fq", "rb") as fh:
     it = fastqandfurious.readfastq_iter(fh, bufsize, entryfunc)
     for entry in it:
         # do something
@@ -182,7 +181,7 @@ def biopython_entryfunc(buf, posarray):
     return entry
 
 bufsize = 20000
-with open("a/fastq/file.fq") as fh:
+with open("a/fastq/file.fq", "rb") as fh:
     it = fastqandfurious.readfastq_iter(fh, bufsize, biopython_entryfunc)
     for entry in it:
         # do something
@@ -203,7 +202,7 @@ def lengthfilter_entryfunc(buf, posarray):
     else:
         return None
 
-with open("a/fastq/file.fq") as fh:
+with open("a/fastq/file.fq", "rb") as fh:
     it = fastqandfurious.readfastq_iter(fh, bufsize, lengthfilter_entryfunc)
     for sequence in it:
         if sequence is None:
@@ -254,7 +253,7 @@ def lengthfilter_entryfunc(buf, posarray):
     else:
         return None
 
-with open("a/fastq/file.fq") as fh:
+with open("a/fastq/file.fq", "rb") as fh:
     it = fastqandfurious.readfastq_iter(fh, bufsize, lengthfilter_entryfunc)
     for sequence in it:
         if sequence is None:


### PR DESCRIPTION
Revised README, as discussed in this issue: https://github.com/lgautier/fastq-and-furious/issues/5

Naturally, one could also do:

```
from fastqandfurious import fastqandfurious

bufsize = 20000
with open("a/fastq/file.fq") as fh:
    it = fastqandfurious.readfastq_iter(fh, bufsize,  fastqandfurious.entryfunc)
    for sequence in it:
        # do something
	pass
```

Either solution works I think